### PR TITLE
[hotfix] fix signUp test

### DIFF
--- a/apph-front/src/tests/components/SignUp.test.tsx
+++ b/apph-front/src/tests/components/SignUp.test.tsx
@@ -40,21 +40,6 @@ describe('Tests du composant SignUp.tsx', () => {
     expect(useNavigate()).toBeCalled();
   });
 
-  it('checks when the server sends an error if missing parameters', () => {
-    //GIVEN
-    cryptoJS.SHA256('P@ssW0rd').toString = jest.fn(() => 'P@ssW0rd');
-    triggerRequestSuccess(JWS_TOKEN);
-    render(<SignUp />);
-    //WHEN
-    fillText(/Email/, 'test@viseo.com');
-    clickButton(/Créer votre compte/);
-    //THEN
-    expect(
-      screen.getByText(/Remplir les champs obligatoires./)
-    ).toBeInTheDocument();
-    expect(useNavigate()).not.toBeCalled();
-  });
-
   it('checks when the server sends an error if invalid email', () => {
     //GIVEN
     cryptoJS.SHA256('P@ssW0rd').toString = jest.fn(() => 'P@ssW0rd');


### PR DESCRIPTION
J'avais oublié de retirer ce test, il est maintenant inutile il n'y a plus de message d'erreur lorsque une textbox est vide 