### PR TITLE
[hotfix][APPH-161] correct large file upload

### DIFF
--- a/apph-back/src/main/resources/application-dev.properties
+++ b/apph-back/src/main/resources/application-dev.properties
@@ -12,6 +12,9 @@ logging.level.root=ERROR
 logging.file.name=apph-back/logs/log.log
 logging.logback.rollingpolicy.file-name-pattern=apph-back/logs/archives/archive%i.%d{yyyy-MM-dd}.gz
 
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
 front-server=http://apph-front-test.s3-website.eu-west-3.amazonaws.com/
 init-database=false
 s3user=dev/

--- a/apph-front/src/services/Server.ts
+++ b/apph-front/src/services/Server.ts
@@ -7,26 +7,18 @@ export default class Server {
     successFunction: (body: string) => void | undefined,
     errorFunction: (error: string) => void
   ) {
-    try {
-      return fetch(BASE_API_URL + URL, requestOptions)
-        .then(async (response) => {
-          const body = await response.text();
-          if (response.ok) {
-            successFunction(body);
-          } else {
-            errorFunction(body);
-          }
-        })
-        .catch((error) => {
-          errorFunction('Échec de connexion au serveur');
-          console.error(error);
-        });
-    } catch (error) {
-      if (error instanceof Error) {
-        errorFunction(error.message);
-      } else {
+    return fetch(BASE_API_URL + URL, requestOptions)
+      .then(async (response) => {
+        const body = await response.text();
+        if (response.ok) {
+          successFunction(body);
+        } else {
+          errorFunction(body);
+        }
+      })
+      .catch((error) => {
+        errorFunction('{"message":"Échec de connexion au serveur"}');
         console.error(error);
-      }
-    }
+      });
   }
 }


### PR DESCRIPTION
Le catch en dehors n'est plus nécessaire si  promise est catché. 
Dans certaines conditions, le message d'erreur n'est pas correctement détecté par errorHandler, donc j'ai mis en format JSON.
La limite de taille n'est pas paramétré dans le propriété.